### PR TITLE
[wip] script to copy Coq's CI info into the platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: GitHub CI
+
+on:
+  - pull_request
+  - push
+
+env:
+  PLATFORM_ARGS: -extent=f -parallel=p -jobs=2 -vst=y -compcert=f
+  OPAM_VERSION: 2.0.6
+
+jobs:
+  Windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v2
+
+      - name: Run common platform script
+        shell: cmd
+        env:
+          COQREGTESTING: y
+        run: coq_platform_make_windows.bat -destcyg=C:\cygwin64_coq_platform -arch=64 %PLATFORM_ARGS%
+
+  Ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install opam
+        run: |
+          sudo apt-get install bubblewrap build-essential
+          curl -L https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-linux > opam.${OPAM_VERSION}
+          chmod a+x opam.${OPAM_VERSION}
+          sudo cp opam.${OPAM_VERSION} /usr/local/bin/opam.${OPAM_VERSION}
+          sudo ln -s /usr/local/bin/opam.${OPAM_VERSION} /usr/local/bin/opam
+
+      - name: Run common platform script
+        shell: bash
+        run: ./coq_platform_make.sh $PLATFORM_ARGS
+
+  Macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install opam
+        run: |
+          curl -L https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-macos > opam.${OPAM_VERSION}
+          chmod a+x opam.${OPAM_VERSION}
+          sudo cp opam.${OPAM_VERSION} /usr/local/bin/opam.${OPAM_VERSION}
+          sudo ln -s /usr/local/bin/opam.${OPAM_VERSION} /usr/local/bin/opam
+
+      - name: Run common platform script
+        shell: bash
+        run: ./coq_platform_make.sh $PLATFORM_ARGS

--- a/shell_scripts/generate_coq_platform_packages_ci.sh
+++ b/shell_scripts/generate_coq_platform_packages_ci.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -e
+
+# This script generates opam/packages/*/*.dev/opam files using Coq's CI
+# project tracking info and generates $OUTPUT mentioning
+# them
+OUTPUT=${OUTPUT:=coq_platform_packages_ci.sh}
+
+TMP=`mktemp -d`
+trap "rm -rf $TMP" EXIT
+
+function log {
+  echo $1
+}
+
+function git_clone {
+  test -d $TMP/git/$1 || (log "DBG: Cloning $1 ..."; git clone $2 -b $3 --depth=1 $TMP/git/$1 >/dev/null 2>&1)
+}
+
+function test_package {
+   printf "%-52s # %s\n" "PACKAGES=\"\${PACKAGES} $1.dev\"" "$2" >> $OUTPUT
+}
+
+function skip_package {
+   printf "#%-51s # %s\n" "PACKAGES=\"\${PACKAGES} $1.dev\"" "$2" >> $OUTPUT
+}
+
+function create_opam_pinned_package {
+  local cip="$1"
+  local package="$2"
+  local REPO_VAR="${cip}_CI_GITURL"
+  local REPO=${!REPO_VAR}
+  local BRANCH_VAR="${cip}_CI_REF"
+  local BRANCH=${!BRANCH_VAR}
+  git_clone $cip ${REPO} ${BRANCH}
+  mkdir -p opam/packages/$package/$package.dev/
+  if [ -e $TMP/git/$cip/$package.opam ]; then
+    cp $TMP/git/$cip/$package.opam opam/packages/$package/$package.dev/opam
+  elif [ -e $TMP/git/$cip/*.opam ]; then
+    cp $TMP/git/$cip/*.opam opam/packages/$package/$package.dev/opam
+  elif [ -e $TMP/git/$cip/opam ]; then
+    cp $TMP/git/$cip/opam opam/packages/$package/$package.dev/opam
+  else
+   log "WARNING: No opam file for $cip $package"
+   skip_package $package "since no opam package found"
+   return
+  fi
+  local HASH=$(cd $TMP/git/$cip/ && git log --oneline | cut -f 1 -d ' ')
+  printf "\nsrc { url : \"%s\" }" "git+${REPO}#${HASH}" >> opam/packages/$package/$package.dev/opam
+  log "INFO: Testing $package at hash $HASH (on branch $BRANCH from $REPO)"
+  test_package $package "${REPO}#${HASH} (on branch $BRANCH)"
+}
+
+# fetch ci info for Coq
+git_clone coq https://github.com/coq/coq.git master
+. git/coq/dev/ci/ci-basic-overlay.sh
+# fake ci project for Coq itself
+project coq "https://github.com/coq/coq.git" "master"
+COQ_CI_PROJECTS="${projects[*]}"
+
+# fetch package list from the current platform
+COQ_PLATFORM_EXTENT=f
+COQ_PLATFORM_COMPCERT=f
+COQ_PLATFORM_VST=y
+. coq_platform_packages.sh
+
+# create the .dev package and their list
+> $OUTPUT
+for pv in $PACKAGES; do
+  package=`echo $pv | sed -e 's/\..*//'`
+  case $package in
+    coqide)
+      create_opam_pinned_package coq $package
+    ;;
+    coq-mathcomp-ssreflect|coq-mathcomp-fingroup|coq-mathcomp-algebra|coq-mathcomp-solvable|coq-mathcomp-field|coq-mathcomp-character)
+      create_opam_pinned_package mathcomp $package
+    ;;
+    coq-hierarchy-builder)  # https://github.com/coq/coq/pull/13633
+      create_opam_pinned_package elpi_hb $package
+    ;;
+    coq-gappa)  # https://github.com/coq/coq/pull/13633
+      create_opam_pinned_package gappa_plugin $package
+    ;;
+    lablgtk3|gappa|menhir) # why are these in the platform?
+      continue
+    ;;
+    *)
+      found=f
+      for cip in $COQ_CI_PROJECTS; do
+          if [ "$found" = "f" -a "${cip/_/-}" = "${package#coq-}" ]; then
+            found=t
+            create_opam_pinned_package ${cip} $package
+          fi
+      done
+      if [ "$found" = "f" ]; then
+          log "WARNING: platform package $package has no corresponding entry in Coq's ci"
+          skip_package $package "no corresponding entry in Coq's ci"
+      fi
+    ;;
+  esac
+done
+
+echo "========================== platform version CI =================="
+cat $OUTPUT


### PR DESCRIPTION
This is a draft script which:
- reads ci info from Coq (which upstream branch is tracked for Coq, may not be the same metadata called dev-repo of opam packages)
- builds a `opam/packages/package/package.dev/opam` file for each package using the upstream opam package (may need fixing, to be seen) and pins the hash currently tested by Coq
- builds `coq_platform_packages_ci.sh` containing the list of `PACKAGES` built that way

The objective is to be able to test the platform scripts on Coq's master on a regular basis.

@Zimmi48 @MSoegtropIMC I think the next step is to hook into some CI infrastructure and see how it goes.
Preferences/Ideas?

Example output:
```
========================== platform version CI ==================
PACKAGES="${PACKAGES} coq.dev"                       # https://github.com/coq/coq.git#6c35e25 (on branch master)
PACKAGES="${PACKAGES} coqide.dev"                    # https://github.com/coq/coq.git#6c35e25 (on branch master)
PACKAGES="${PACKAGES} coq-unicoq.dev"                # https://github.com/unicoq/unicoq#8ea4f91 (on branch master)
PACKAGES="${PACKAGES} coq-ext-lib.dev"               # https://github.com/coq-community/coq-ext-lib#159c361 (on branch master)
PACKAGES="${PACKAGES} coq-equations.dev"             # https://github.com/mattam82/Coq-Equations#3d44714 (on branch master)
PACKAGES="${PACKAGES} coq-bignums.dev"               # https://github.com/coq/bignums#2b3492f (on branch master)
PACKAGES="${PACKAGES} coq-aac-tactics.dev"           # https://github.com/coq-community/aac-tactics#ea63306 (on branch master)
PACKAGES="${PACKAGES} coq-mtac2.dev"                 # https://github.com/Mtac2/Mtac2#9a9956d (on branch master)
PACKAGES="${PACKAGES} coq-simple-io.dev"             # https://github.com/Lysxia/coq-simple-io#09c164d (on branch master)
PACKAGES="${PACKAGES} coq-quickchick.dev"            # https://github.com/QuickChick/QuickChick#cef4740 (on branch master)
PACKAGES="${PACKAGES} coq-flocq.dev"                 # https://gitlab.inria.fr/flocq/flocq#8fdb8b1 (on branch master)
PACKAGES="${PACKAGES} coq-coquelicot.dev"            # https://gitlab.inria.fr/coquelicot/coquelicot#88a9e56 (on branch master)
PACKAGES="${PACKAGES} coq-gappa.dev"                 # https://gitlab.inria.fr/gappa/coq#3935dfe (on branch master)
PACKAGES="${PACKAGES} coq-interval.dev"              # https://gitlab.inria.fr/coqinterval/interval#86aa3c0 (on branch master)
PACKAGES="${PACKAGES} coq-elpi.dev"                  # https://github.com/LPCIC/coq-elpi#29d18e4 (on branch coq-master)
PACKAGES="${PACKAGES} coq-hierarchy-builder.dev"     # https://github.com/math-comp/hierarchy-builder#dc171e0 (on branch coq-master)
PACKAGES="${PACKAGES} coq-mathcomp-ssreflect.dev"    # https://github.com/math-comp/math-comp#7da602f (on branch master)
PACKAGES="${PACKAGES} coq-mathcomp-fingroup.dev"     # https://github.com/math-comp/math-comp#7da602f (on branch master)
PACKAGES="${PACKAGES} coq-mathcomp-algebra.dev"      # https://github.com/math-comp/math-comp#7da602f (on branch master)
PACKAGES="${PACKAGES} coq-mathcomp-solvable.dev"     # https://github.com/math-comp/math-comp#7da602f (on branch master)
PACKAGES="${PACKAGES} coq-mathcomp-field.dev"        # https://github.com/math-comp/math-comp#7da602f (on branch master)
PACKAGES="${PACKAGES} coq-mathcomp-character.dev"    # https://github.com/math-comp/math-comp#7da602f (on branch master)
#PACKAGES="${PACKAGES} coq-mathcomp-bigenough.dev"   # no corresponding entry in Coq's ci
#PACKAGES="${PACKAGES} coq-mathcomp-finmap.dev"      # no corresponding entry in Coq's ci
#PACKAGES="${PACKAGES} coq-mathcomp-real-closed.dev" # no corresponding entry in Coq's ci
#PACKAGES="${PACKAGES} coq-menhirlib.dev"            # since no opam package found
#PACKAGES="${PACKAGES} coq-compcert.dev"             # since no opam package found
PACKAGES="${PACKAGES} coq-vst.dev"                   # https://github.com/PrincetonUniversity/VST#7b3946f (on branch master)
```
