### PR TITLE
[ci] GH actions for windows, linux and osx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,135 @@
+# Main doc: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/introduction-to-github-actions
+# Runners spec: https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners
+# Glob expressions: https://github.com/actions/toolkit/tree/main/packages/glob
+
+name: Coq Platform CI
+
+###############################################################################
+# Schedule:
+# - push on any branch whose name matches v** or master
+# - any pull request
+###############################################################################
+on:
+  push:
+    branches:
+      - v**
+      - master
+  pull_request:
+    branches:
+      - '**'
+
+###############################################################################
+# Platform script options shared among all jobs
+###############################################################################
+env:
+  PLATFORM_ARGS: -extent=f -parallel=p -jobs=2 -vst=y -compcert=f
+  COQREGTESTING: y
+
+jobs:
+###############################################################################
+# Windows
+#
+# 2 jobs, the former builds the installer, the second tests it
+#
+# CAVEATS:
+# - git is misconfigured, by default it puts \r in between \n\n
+###############################################################################
+  Windows_platform:
+    name: Windows
+    runs-on: windows-latest
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Run common platform script
+        shell: cmd
+        run: coq_platform_make_windows.bat -destcyg=C:\cygwin64_coq_platform -arch=64 %PLATFORM_ARGS%
+
+      - name: Create installer
+        shell: cmd
+        run: C:\cygwin64_coq_platform\bin\bash --login -c "cd coq-platform/ && windows/create_installer_windows.sh && mkdir /cygdrive/c/installer && cp windows_installer/*exe /cygdrive/c/installer/"
+
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'Windows installer 64 bits'
+          path: C:\installer\*.exe
+          retention-days: 5
+
+  Windows_smoke:
+    name: Smoke test
+    needs: Windows_platform
+    runs-on: windows-latest
+
+    steps:
+      - name: 'Download Artifact'
+        uses: actions/download-artifact@v2
+        with:
+          name: 'Windows installer 64 bits'
+
+      - name: 'Run Installer'
+        shell: cmd
+        run: |
+          CD C:\installer\
+          FOR %%f IN (*.exe) DO %%f /S /D=C:\Coq
+
+      - name: 'Smoke coqc'
+        shell: cmd
+        run: C:\Coq\bin\coqc.exe -v
+
+###############################################################################
+# Ubuntu
+#
+# CAVEATS:
+# - you need bubblewrap or the script fails
+# - build-essential pulls in the C toolchain
+###############################################################################
+  Ubuntu_platform:
+    name: Ubuntu
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Install bubblewrap and build-essential
+        run: |
+          sudo apt-get update
+          sudo apt-get install bubblewrap build-essential
+
+      - name: Run common platform script
+        shell: bash
+        run: ./coq_platform_make.sh $PLATFORM_ARGS
+
+###############################################################################
+# Macos
+#
+# CAVEATS:
+# - COQREGTESTING broken, it makes the script loop, so we install opam by hand
+###############################################################################
+  Macos_platform:
+    name: Macos
+    runs-on: macos-latest
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Install opam
+        env:
+          OPAM_VERSION: 2.0.7
+        run: |
+          curl -L https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/opam-${OPAM_VERSION}-x86_64-macos > opam.${OPAM_VERSION}
+          chmod a+x opam.${OPAM_VERSION}
+          sudo cp opam.${OPAM_VERSION} /usr/local/bin/opam.${OPAM_VERSION}
+          sudo ln -s /usr/local/bin/opam.${OPAM_VERSION} /usr/local/bin/opam
+
+      - name: Run common platform script
+        shell: bash
+        run: ./coq_platform_make.sh $PLATFORM_ARGS


### PR DESCRIPTION
I've extracted from #44 the commit adding CI to the platform, based on work by @Zimmi48. Two things before merge:
- [x] avoid the GH action to run CI twice (see this PR, it's both a push and a pull_request)
- [x] fix the windows job (I kind of recall having seen the `bad file descriptor` problem before)

This commit should work just fine on the v8.12 branch