### PR TITLE
CompCert: add back after adjusting Flocq to flocq-3 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ The master branch contains a reduced list of packages - those where the master b
 The list of included packages is:
 ```
 coq                       dev             Formal proof management system
-coq-aac-tactics           dev             This Coq plugin provides tactics for rewriting universally quantified equat
+coq-aac-tactics           dev             This Coq plugin provides tactics for rewriting universally quantified equations, modulo associative (and possibly commutative) operators
 coq-bignums               dev             Bignums, the Coq library of arbitrary large numbers
+coq-compcert              dev             The CompCert C compiler (64 bit)
 coq-coquelicot            dev             A Coq formalization of real analysis compatible with the standard library.
 coq-elpi                  dev             Elpi extension language for Coq
 coq-equations             dev             A function definition package for Coq
 coq-ext-lib               dev             a library of Coq definitions, theorems, and tactics
-coq-flocq                 dev             A floating-point formalization for the Coq system.
-coq-gappa                 dev             A Coq tactic for discharging goals about floating-point arithmetic and roun
+coq-flocq                 3.dev           A floating-point formalization for the Coq system.
+coq-gappa                 dev             A Coq tactic for discharging goals about floating-point arithmetic and round-off errors using the Gappa prover
 coq-hierarchy-builder     dev             Hierarchy Builder
 coq-interval              dev             A Coq tactic for proving bounds on real-valued expressions automatically
 coq-mathcomp-algebra      dev             Mathematical Components Library on Algebra
@@ -52,7 +53,7 @@ coq-mathcomp-bigenough    dev             A small library to do epsilon - N reas
 coq-mathcomp-character    dev             Mathematical Components Library on character theory
 coq-mathcomp-field        dev             Mathematical Components Library on Fields
 coq-mathcomp-fingroup     dev             Mathematical Components Library on finite groups
-coq-mathcomp-finmap       dev             Finite sets, finite maps, finitely supported functions, orders
+coq-mathcomp-finmap       dev             Finite sets, finite maps, finitely supported functions
 coq-mathcomp-real-closed  dev             Mathematical Components Library on real closed fields
 coq-mathcomp-solvable     dev             Mathematical Components Library on finite groups (II)
 coq-mathcomp-ssreflect    dev             Small Scale Reflection
@@ -61,12 +62,13 @@ coq-mtac2                 dev             Mtac2: Typed Tactics for Coq
 coq-quickchick            dev             QuickChick is a random property-based testing library for Coq.
 coq-simple-io             dev             IO monad for Coq
 coq-unicoq                dev             An enhanced unification algorithm for Coq
-gappa                     dev             Tool intended for formally proving properties on numerical programs dealing
+coqide                    dev             IDE of the Coq formal proof management system
+gappa                     dev             Tool intended for formally proving properties on numerical programs dealing with floating-point or fixed-point arithmetic
 menhir                    dev             An LR(1) parser generator
 ```
 Currently not supported are
 - coq-vst (likely cause: incompatible with CompCert master)
-- coq-compcert (likely cause: incompatible with Flocq master)
+- coq-flocq is tied to the `flocq-3` branch since CompCert is not yet compatible with latest Flocq
 
 # Installation of the master branch
 

--- a/coq_platform_packages.sh
+++ b/coq_platform_packages.sh
@@ -37,7 +37,7 @@ PACKAGES="${PACKAGES} coq-simple-io.dev"
 PACKAGES="${PACKAGES} coq-quickchick.dev"
 
 # Analysis and numerics
-PACKAGES="${PACKAGES} coq-flocq.dev"
+PACKAGES="${PACKAGES} coq-flocq.3.dev"
 PACKAGES="${PACKAGES} coq-coquelicot.dev"
 PACKAGES="${PACKAGES} coq-gappa.dev"
 PACKAGES="${PACKAGES} coq-interval.dev"
@@ -61,12 +61,12 @@ PACKAGES="${PACKAGES} coq-mathcomp-real-closed.dev"
 # Menhir, CompCert and Princeton VST - these take longer to compile !
 PACKAGES="${PACKAGES} coq-menhirlib.dev menhir.dev"
 # Todo: there is no mutex between coq platform and coq platform open source
-# case "$COQ_PLATFORM_COMPCERT" in
-#   [fF]) PACKAGES="${PACKAGES} coq-compcert.dev" ;;
-#   [oO]) "The open source variant of CompCert is notsupp orted in the master/dev branch"; exit 1 ;;
-#   [nN]) true ;;
-#   *) echo "Illegal value for COQ_PLATFORM_COMPCERT - aborting"; false ;;
-# esac
+case "$COQ_PLATFORM_COMPCERT" in
+  [fF]) PACKAGES="${PACKAGES} coq-compcert.dev" ;;
+  [oO]) "The open source variant of CompCert is notsupp orted in the master/dev branch"; exit 1 ;;
+  [nN]) true ;;
+  *) echo "Illegal value for COQ_PLATFORM_COMPCERT - aborting"; false ;;
+esac
 
 # case "$COQ_PLATFORM_VST" in
 #   [yY]) PACKAGES="${PACKAGES} coq-vst.dev" ;;

--- a/opam/packages/coq-compcert-32/coq-compcert-32.dev/opam
+++ b/opam/packages/coq-compcert-32/coq-compcert-32.dev/opam
@@ -33,7 +33,7 @@ depends: [
   "coq" {>= "8.8" | = "dev"}
   "menhir" {>= "20190626" | = "dev"}
   "ocaml" {>= "4.05.0"}
-  "coq-flocq" {>= "3.1.0" | = "dev"}
+  "coq-flocq" { (>= "3.1.0" & < "3.4") | (= "3.dev") }
   "coq-menhirlib" {>= "20190626" | = "dev"}
 ]
 synopsis: "The CompCert C compiler (32 bit)"

--- a/opam/packages/coq-compcert/coq-compcert.dev/opam
+++ b/opam/packages/coq-compcert/coq-compcert.dev/opam
@@ -32,7 +32,7 @@ depends: [
   "coq" {>= "8.8.0" | = "dev"}
   "menhir" {>= "20190626" | = "dev"}
   "ocaml" {>= "4.05.0"}
-  "coq-flocq" {>= "3.1.0" | = "dev"}
+  "coq-flocq" { (>= "3.1.0" & < "3.4") | (= "3.dev") }
   "coq-menhirlib" {>= "20190626" | = "dev"}
 ]
 synopsis: "The CompCert C compiler (64 bit)"

--- a/opam/packages/coq-flocq/coq-flocq.3.dev/opam
+++ b/opam/packages/coq-flocq/coq-flocq.3.dev/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "guillaume.melquiond@inria.fr"
+homepage: "http://flocq.gforge.inria.fr/"
+dev-repo: "git+https://scm.gforge.inria.fr/anonscm/git/flocq/flocq.git"
+license: "LGPL 3"
+build: [
+  ["autoconf"]
+  ["./configure"]
+  ["./remake" "-j%{jobs}%"]
+]
+install: ["./remake" "install"]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Flocq"]
+depends: [
+  "ocaml"
+  "coq" {= "dev"}
+]
+tags: [ "keyword:floating point arithmetic" ]
+authors: [ "Sylvie Boldo <sylvie.boldo@inria.fr>" "Guillaume Melquiond <guillaume.melquiond@inria.fr>" ]
+synopsis: "A floating-point formalization for the Coq system."
+flags: light-uninstall
+url {
+  src: "git+https://gitlab.inria.fr/flocq/flocq.git#flocq-3"
+}


### PR DESCRIPTION
Add back CompCert after switching to Flocq-3.

Note: The man page issue seen in opam-coq-archive CI d