### PR TITLE
Cygwin32: remove tar patch - seems to be fixed upstream

### DIFF
--- a/shell_scripts/init_cygwin_fixes.sh
+++ b/shell_scripts/init_cygwin_fixes.sh
@@ -18,18 +18,6 @@ then
   ln -s -f /usr/bin/python2 /usr/bin/python
 fi
 
-###################### Fix tar in 32 bit cygwin #####################
-
-# Cygwin updated to tar 1.33 which is broken on Cygwin 32
-
-if [[ "$OSTYPE" == cygwin ]]
-then
-  if [ "`uname -m`" = "i686" ]; then
-    wget http://mirrors.kernel.org/sourceware/cygwin/x86/release/tar/tar-1.32-2.tar.xz -O /tmp/tar-1.32-2.tar.xz
-    tar xvf /tmp/tar-1.32-2.tar.xz -C /
-  fi
-fi
-
 ###################### Fix binutils in 64 bit cygwin #####################
 
 # Cygwin updated to mingw64-x86_64-binutils is broken on Cygwin 64


### PR DESCRIPTION
There is a new release of tar in Cygwin, which likely fixes the observed issues for Cygwin 32.

Update: looks like this was a misunderstanding.