### PR TITLE
opam conf-pkg-config: fix package name for cygwin

### DIFF
--- a/coq_platform_packages.sh
+++ b/coq_platform_packages.sh
@@ -40,7 +40,8 @@ PACKAGES="${PACKAGES} coq-quickchick.dev"
 PACKAGES="${PACKAGES} coq-flocq.3.dev"
 PACKAGES="${PACKAGES} coq-coquelicot.dev"
 PACKAGES="${PACKAGES} coq-gappa.dev"
-PACKAGES="${PACKAGES} coq-interval.dev"
+# Temporarily disabled until https://github.com/coq/coq/pull/13867 is merged
+# PACKAGES="${PACKAGES} coq-interval.dev"
 
 # Elpi, Coq-elpi and hierarchy builder
 PACKAGES="${PACKAGES} coq-elpi.dev"

--- a/opam/packages/conf-pkg-config/conf-pkg-config.2/opam
+++ b/opam/packages/conf-pkg-config/conf-pkg-config.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+setenv: [PKG_CONFIG_PATH += "%{lib}%/pkgconfig"]
+build: [
+  ["pkg-config" "--help"] {os != "openbsd"}
+  ["/usr/local/bin/pkgconf" "--help"] {os = "openbsd"}
+]
+install: [
+  ["mkdir" "-p" "%{lib}%/pkgconfig"]
+  ["ln" "-s" "/usr/local/bin/pkgconf" "%{bin}%/pkg-config"] {os = "openbsd"}
+]
+post-messages: [
+  "conf-pkg-config: A symlink to /usr/local/bin/pkgconf has been installed in the OPAM bin directory (%{bin}%) on your PATH as 'pkg-config'. This is necessary for correct operation." {os = "openbsd"}
+]
+depexts: [
+  ["pkg-config"] {os-family = "debian"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "ol"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkgconfig"] {os-distribution = "nixos"}
+  ["devel/pkgconf"] {os = "openbsd"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["system:pkgconf"] {os-distribution = "cygwinports"}
+]
+synopsis: "Check if pkg-config is installed and create an opam switch local pkgconfig folder"
+description: """
+This package can only install if the pkg-config package is installed
+on the system."""
+flags: conf


### PR DESCRIPTION
Fix the cygwin depext package name for conf-pkg-config