### PR TITLE
Avoid failing when an older version of cygwin is already installed

### DIFF
--- a/coq_platform_make.sh
+++ b/coq_platform_make.sh
@@ -15,7 +15,7 @@ source shell_scripts/init_safety_debug.sh
 source shell_scripts/init_paths.sh
 source shell_scripts/init_utilities.sh
 source shell_scripts/init_machine_type.sh
-source shell_scripts/init_cygwin_fixes.sh
+source shell_scripts/init_cygwin_fixes.sh || echo; echo "*** WARNING: Unable to update cygwin, continuing ***"
 
 ###################### SETTINGS #####################
 


### PR DESCRIPTION
Fixes #121 