### PR TITLE
Windows: test if new cygwin 64 binutils work reliably

### DIFF
--- a/shell_scripts/init_cygwin_fixes.sh
+++ b/shell_scripts/init_cygwin_fixes.sh
@@ -29,15 +29,3 @@ then
     tar xvf /tmp/tar-1.32-2.tar.xz -C /
   fi
 fi
-
-###################### Fix binutils in 64 bit cygwin #####################
-
-# Cygwin updated to mingw64-x86_64-binutils is broken on Cygwin 64
-
-if [[ "$OSTYPE" == cygwin ]]
-then
-  if [ "`uname -m`" = "x86_64" ]; then
-    wget http://mirrors.kernel.org/sourceware/cygwin/x86_64/release/mingw64-x86_64-binutils/mingw64-x86_64-binutils-2.35.1-1.tar.xz -O /tmp/mingw64-x86_64-binutils-2.35.1-1.tar.xz
-    tar xvf /tmp/mingw64-x86_64-binutils-2.35.1-1.tar.xz -C /
-  fi
-fi


### PR DESCRIPTION
Currently binutils are patched with an older version, because the latest version was unreliable.

There is a new version which is tested with this PR by removing the patch.