### PR TITLE
Windows: improved consistency of cygwin cache path

### DIFF
--- a/coq_platform_make_windows.bat
+++ b/coq_platform_make_windows.bat
@@ -41,7 +41,9 @@ REM THIS MUST NOT INCLUDE THE TRAILING /
 SET CYGWIN_REPOSITORY=https://mirrors.kernel.org/sourceware/cygwin
 
 REM A local folder (in Windows path syntax) where cygwin packages are cached
-IF EXIST %TEMP%\NUL (
+IF EXIST %LOCALAPPDATA%\Temp\NUL (
+  SET CYGWIN_LOCAL_CACHE_WFMT=%LOCALAPPDATA%\Temp\coq_platform_cygwin_cache
+) ELSE IF EXIST %TEMP%\NUL (
   SET CYGWIN_LOCAL_CACHE_WFMT=%TEMP%\coq_platform_cygwin_cache
 ) ELSE IF EXIST %TMP%\NUL (
   SET CYGWIN_LOCAL_CACHE_WFMT=%TMP%\coq_platform_cygwin_cache


### PR DESCRIPTION
This PR improves the consistency of the used cygwin cache folder path in case `coq_platform_make_windows.bat` is called from cygwin (not that uncommon to clone the repo in another cygwin).