### PR TITLE
Windows: move nsis download URL to coq/prerequisites

### DIFF
--- a/windows/create_installer_windows.sh
+++ b/windows/create_installer_windows.sh
@@ -401,7 +401,7 @@ cd $DIR_TARGET
 
 # NSIS 2.51 has the bug that $0 is not set in .onSelChange, so use the latest version 3.06.1
 
-wget --no-clobber --progress=dot:giga https://sourceforge.net/projects/nsis/files/NSIS%203/3.06.1/nsis-3.06.1.zip/download -O nsis-3.06.1.zip
+wget --no-clobber --progress=dot:giga https://github.com/coq/prerequisites/releases/download/2021.02.2/nsis-3.06.1.zip
 unzip -o nsis-3.06.1
 # Unzipping this results in very strange permissions - fix this
 chmod -R 700 nsis-3.06.1


### PR DESCRIPTION
Since the new SF download URL for NSIS didn't prove terribly stable either, we created a new github project coq/prerequisites to host the prerequisite tar balls in a stable way.

This PR moves the NSIS download URL to this new repo.