### PR TITLE
Added new pick 8.13~2021.09

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         variant:
           - '8.14'
-          - '8.13'
+          - '8.13~2021.09'
 
     steps:
       - name: Git checkout
@@ -124,7 +124,7 @@ jobs:
       matrix:
         variant:
           - '8.14'
-          - '8.13'
+          - '8.13~2021.09'
 
     steps:
       - name: Install bash

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         variant:
           - '8.14'
-          - '8.13'
+          - '8.13~2021.09'
 
     steps:
       - name: Git checkout

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,7 +54,7 @@ jobs:
           - '64'
         variant:
           - '8.14'
-          - '8.13'
+          - '8.13~2021.09'
 
     steps:
       - name: Set git to use LF
@@ -107,7 +107,7 @@ jobs:
           - '64'
         variant:
           - '8.14'
-          - '8.13'
+          - '8.13~2021.09'
 
     steps:
       - name: 'Download Artifact'

--- a/versions/packages-8.13~2021.02.sh
+++ b/versions/packages-8.13~2021.02.sh
@@ -11,18 +11,18 @@
 ###################### CONTROL VARIABLES #####################
 
 # The two lines below are used by the package selection script
-# DESCRIPTION Coq 8.12.2 12/2020 (previous release version)
-# SORTORDER 3
+# DESCRIPTION Coq 8.13.2 04/2021 with original package pick 02/2021
+# SORTORDER 2
 
 # The package list name is the final part of the opam switch name.
 # It is usually either empty ot starts with ~.
 # It might also be used for installer package names, but with ~ replaced by _
 # It is also used for version specific file selections in the smoke test kit.
-COQ_PLATFORM_PACKAGELIST_NAME='~8.12'
+COQ_PLATFORM_PACKAGELIST_NAME='~8.13~2021.02'
 
 # The corresponding Coq development branch and tag
-COQ_PLATFORM_COQ_BRANCH='v8.12'
-COQ_PLATFORM_COQ_TAG='8.12.2'
+COQ_PLATFORM_COQ_BRANCH='v8.13'
+COQ_PLATFORM_COQ_TAG='8.13.2'
 
 # This controls if opam repositories for development packages are selected
 COQ_PLATFORM_USE_DEV_REPOSITORY='N'
@@ -35,62 +35,65 @@ COQ_PLATFORM_USE_DEV_REPOSITORY='N'
 # - Packages which take a long time to build should be given last.
 #   There is some evidence that they are built early then.
 
-
-PACKAGES="coq.8.12.2"
+PACKAGES="coq.8.13.2"
 
 # GTK based IDE for Coq - alternatives are VSCoq and Proofgeneral for Emacs
 if  [[ "${COQ_PLATFORM_EXTENT}"  =~ ^[iIfF] ]]
 then
-PACKAGES="${PACKAGES} coqide.8.12.2 lablgtk3.3.1.1"
+PACKAGES="${PACKAGES} coqide.8.13.2 lablgtk3.3.1.1"
 fi
 
 if  [[ "${COQ_PLATFORM_EXTENT}"  =~ ^[fF] ]]
 then
 
 # Some generally useful packages
-PACKAGES="${PACKAGES} coq-unicoq.1.5+8.12"
-PACKAGES="${PACKAGES} coq-ext-lib.0.11.2"
-PACKAGES="${PACKAGES} coq-equations.1.2.3+8.12"
-PACKAGES="${PACKAGES} coq-bignums.8.12.0"
-PACKAGES="${PACKAGES} coq-aac-tactics.8.12.0"
-PACKAGES="${PACKAGES} coq-mtac2.1.3+8.12"
-PACKAGES="${PACKAGES} coq-simple-io.1.4.0"
-PACKAGES="${PACKAGES} coq-quickchick.1.4.0"
+PACKAGES="${PACKAGES} coq-unicoq.1.5+8.13"
+PACKAGES="${PACKAGES} coq-ext-lib.0.11.3"
+PACKAGES="${PACKAGES} coq-equations.1.2.3+8.13"
+PACKAGES="${PACKAGES} coq-bignums.8.13.0"
+PACKAGES="${PACKAGES} coq-aac-tactics.8.13.0"
+PACKAGES="${PACKAGES} coq-mtac2.1.4+8.13"
+PACKAGES="${PACKAGES} coq-simple-io.1.5.0"
 
 # Analysis and numerics
 PACKAGES="${PACKAGES} coq-flocq.3.3.1"
-PACKAGES="${PACKAGES} coq-coquelicot.3.1.0"
-PACKAGES="${PACKAGES} coq-gappa.1.4.4 gappa.1.3.5"
-PACKAGES="${PACKAGES} coq-interval.4.0.0"
+PACKAGES="${PACKAGES} coq-gappa.1.4.6 gappa.1.3.5"
 
 # Elpi, Coq-elpi and hierarchy builder
-PACKAGES="${PACKAGES} coq-elpi.1.5.1 elpi.1.11.4-1"
-PACKAGES="${PACKAGES} coq-hierarchy-builder.0.10.0"
+PACKAGES="${PACKAGES} coq-elpi.1.8.1 elpi.1.12.0"
+PACKAGES="${PACKAGES} coq-hierarchy-builder.1.0.0"
 
 # The standard set of mathcomp modules
-PACKAGES="${PACKAGES} coq-mathcomp-ssreflect.1.11.0"
-PACKAGES="${PACKAGES} coq-mathcomp-fingroup.1.11.0"
-PACKAGES="${PACKAGES} coq-mathcomp-algebra.1.11.0"
-PACKAGES="${PACKAGES} coq-mathcomp-solvable.1.11.0"
-PACKAGES="${PACKAGES} coq-mathcomp-field.1.11.0"
-PACKAGES="${PACKAGES} coq-mathcomp-character.1.11.0"
+PACKAGES="${PACKAGES} coq-mathcomp-ssreflect.1.12.0"
+PACKAGES="${PACKAGES} coq-mathcomp-fingroup.1.12.0"
+PACKAGES="${PACKAGES} coq-mathcomp-algebra.1.12.0"
+PACKAGES="${PACKAGES} coq-mathcomp-solvable.1.12.0"
+PACKAGES="${PACKAGES} coq-mathcomp-field.1.12.0"
+PACKAGES="${PACKAGES} coq-mathcomp-character.1.12.0"
 # Plus a few extra mathcomp modules
 PACKAGES="${PACKAGES} coq-mathcomp-bigenough.1.0.0"
-PACKAGES="${PACKAGES} coq-mathcomp-finmap.1.5.0"
-PACKAGES="${PACKAGES} coq-mathcomp-real-closed.1.1.1"
+PACKAGES="${PACKAGES} coq-mathcomp-finmap.1.5.1"
+PACKAGES="${PACKAGES} coq-mathcomp-real-closed.1.1.2"
+
+# Packages depending on mathcomp
+PACKAGES="${PACKAGES} coq-coquelicot.3.1.0"
+PACKAGES="${PACKAGES} coq-interval.4.1.1"
+PACKAGES="${PACKAGES} coq-quickchick.1.5.0"
+
+# Homotopy Type Theory (HoTT)
+PACKAGES="${PACKAGES} coq-hott.8.13"
 
 # Menhir, CompCert and Princeton VST - these take longer to compile !
 PACKAGES="${PACKAGES} coq-menhirlib.20200624 menhir.20200624"
-# Todo: there is no mutex between coq platform and coq platform open source
+
 case "$COQ_PLATFORM_COMPCERT" in
-  [yYfF]) PACKAGES="${PACKAGES} coq-compcert.3.7+8.12~coq_platform" ;;
-  [oO]) PACKAGES="${PACKAGES} coq-compcert.3.7+8.12~coq_platform~open_source" ;;
+  [yY]) PACKAGES="${PACKAGES} coq-compcert.3.8" ;;
   [nN]) true ;;
   *) echo "Illegal value for COQ_PLATFORM_COMPCERT - aborting"; false ;;
 esac
 
 case "$COQ_PLATFORM_VST" in
-  [yY]) PACKAGES="${PACKAGES} coq-vst.2.6" ;;
+  [yY]) PACKAGES="${PACKAGES} coq-vst.2.7.1" ;;
   [nN]) true ;;
   *) echo "Illegal value for COQ_PLATFORM_VST - aborting"; false ;;
 esac

--- a/versions/packages-8.13~2021.09.sh
+++ b/versions/packages-8.13~2021.09.sh
@@ -11,14 +11,14 @@
 ###################### CONTROL VARIABLES #####################
 
 # The two lines below are used by the package selection script
-# DESCRIPTION Coq 8.13.2 04/2021 with package pick 02/2021
+# DESCRIPTION Coq 8.13.2 04/2021 with updated package pick 09/2021
 # SORTORDER 1
 
 # The package list name is the final part of the opam switch name.
 # It is usually either empty ot starts with ~.
 # It might also be used for installer package names, but with ~ replaced by _
 # It is also used for version specific file selections in the smoke test kit.
-COQ_PLATFORM_PACKAGELIST_NAME=''
+COQ_PLATFORM_PACKAGELIST_NAME='~8.13~2021.09'
 
 # The corresponding Coq development branch and tag
 COQ_PLATFORM_COQ_BRANCH='v8.13'
@@ -48,23 +48,20 @@ then
 
 # Some generally useful packages
 PACKAGES="${PACKAGES} coq-unicoq.1.5+8.13"
-PACKAGES="${PACKAGES} coq-ext-lib.0.11.3"
+PACKAGES="${PACKAGES} coq-ext-lib.0.11.4"
 PACKAGES="${PACKAGES} coq-equations.1.2.3+8.13"
 PACKAGES="${PACKAGES} coq-bignums.8.13.0"
 PACKAGES="${PACKAGES} coq-aac-tactics.8.13.0"
 PACKAGES="${PACKAGES} coq-mtac2.1.4+8.13"
 PACKAGES="${PACKAGES} coq-simple-io.1.5.0"
-PACKAGES="${PACKAGES} coq-quickchick.1.5.0"
 
 # Analysis and numerics
-PACKAGES="${PACKAGES} coq-flocq.3.3.1"
-PACKAGES="${PACKAGES} coq-coquelicot.3.1.0"
-PACKAGES="${PACKAGES} coq-gappa.1.4.6 gappa.1.3.5"
-PACKAGES="${PACKAGES} coq-interval.4.1.1"
+PACKAGES="${PACKAGES} coq-flocq.3.4.2"
+PACKAGES="${PACKAGES} coq-gappa.1.5.0 gappa.1.4.0"
 
 # Elpi, Coq-elpi and hierarchy builder
-PACKAGES="${PACKAGES} coq-elpi.1.8.1 elpi.1.12.0"
-PACKAGES="${PACKAGES} coq-hierarchy-builder.1.0.0"
+PACKAGES="${PACKAGES} coq-elpi.1.9.7 elpi.1.13.7"
+PACKAGES="${PACKAGES} coq-hierarchy-builder.1.1.0"
 
 # The standard set of mathcomp modules
 PACKAGES="${PACKAGES} coq-mathcomp-ssreflect.1.12.0"
@@ -78,20 +75,25 @@ PACKAGES="${PACKAGES} coq-mathcomp-bigenough.1.0.0"
 PACKAGES="${PACKAGES} coq-mathcomp-finmap.1.5.1"
 PACKAGES="${PACKAGES} coq-mathcomp-real-closed.1.1.2"
 
+# Packages depending on mathcomp
+PACKAGES="${PACKAGES} coq-coquelicot.3.2.0"
+PACKAGES="${PACKAGES} coq-interval.4.3.0"
+PACKAGES="${PACKAGES} coq-quickchick.1.5.1"
+
 # Homotopy Type Theory (HoTT)
 PACKAGES="${PACKAGES} coq-hott.8.13"
 
 # Menhir, CompCert and Princeton VST - these take longer to compile !
-PACKAGES="${PACKAGES} coq-menhirlib.20200624 menhir.20200624"
-# Todo: there is no mutex between coq platform and coq platform open source
+PACKAGES="${PACKAGES} coq-menhirlib.20210419 menhir.20210419"
+
 case "$COQ_PLATFORM_COMPCERT" in
-  [yY]) PACKAGES="${PACKAGES} coq-compcert.3.8" ;;
+  [yY]) PACKAGES="${PACKAGES} coq-compcert.3.9" ;;
   [nN]) true ;;
   *) echo "Illegal value for COQ_PLATFORM_COMPCERT - aborting"; false ;;
 esac
 
 case "$COQ_PLATFORM_VST" in
-  [yY]) PACKAGES="${PACKAGES} coq-vst.2.7.1" ;;
+  [yY]) PACKAGES="${PACKAGES} coq-vst.2.8" ;;
   [nN]) true ;;
   *) echo "Illegal value for COQ_PLATFORM_VST - aborting"; false ;;
 esac

--- a/versions/packages-8.14.sh
+++ b/versions/packages-8.14.sh
@@ -87,7 +87,6 @@ PACKAGES="${PACKAGES} coq-hott.8.13~flex"
 # Menhir, CompCert and Princeton VST - these take longer to compile !
 PACKAGES="${PACKAGES} coq-menhirlib.20210419 menhir.20210419" # pick confirmed https://gitlab.inria.fr/fpottier/menhir/-/issues/55
 
-# Todo: there is no mutex between coq platform and coq platform open source
 case "$COQ_PLATFORM_COMPCERT" in
   [yY]) PACKAGES="${PACKAGES} coq-compcert.3.9~flex" ;;
   [nN]) true ;;


### PR DESCRIPTION
This PR adds a new pick for Coq 8.13 with all packages updates to the latest working / compatible version. The original 2021.02 pick is kept as a different version.