### PR TITLE
Add Publisher to Registry Entries

### DIFF
--- a/windows/Coq.nsi
+++ b/windows/Coq.nsi
@@ -87,6 +87,8 @@ Section "-CoqWinStuff" Sec_CoqWinStuff
       "UninstallString" '"$INSTDIR\Uninstall.exe"'
   WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\Coq" \
       "DisplayVersion" "${VERSION}"
+  WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\Coq" \
+      "Publisher" "The Coq Team"
   WriteRegDWORD HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\Coq" \
       "NoModify" "1"
   WriteRegDWORD HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\Coq" \


### PR DESCRIPTION
It is best practice to include the publisher name in the Add/Remove Programs table on Windows. This change sets the publisher name for the package