### PR TITLE
Map the package options with descriptions

### DIFF
--- a/shell_scripts/ask_introduction.sh
+++ b/shell_scripts/ask_introduction.sh
@@ -18,10 +18,10 @@ cat <<EOH
 ====================== JUST COQ OR COMPLETE PLATFORM ? =======================
 This script installs the Coq Platform release $COQ_PLATFORM_RELEASE, that is:
 
-- the Coq compiler and Coq's standard library
-- optionally CoqIDE, a GTK3 based graphical user interface
-- optionally various widely used Coq libraries and plugins
-- optionally an extended set of Coq libraries and plugins
+- the Coq compiler and Coq's standard library (b)
+- optionally CoqIDE, a GTK3 based graphical user interface (i)
+- optionally various widely used Coq libraries and plugins (f)
+- optionally an extended set of Coq libraries and plugins (x)
 
 The script uses opam, the OCaml package manager, to do all the work.
 In case opam is not yet installed, it will install opam.


### PR DESCRIPTION
If there is a better way to do this, please feel free to edit. I was wrongly under the impression that full > extended having not read the description very carefully and as the order of these options' descriptions did not match the options presented.