### PR TITLE
[snap] do not purge lib/coq-core

### DIFF
--- a/linux/snap/snapcraft.yaml.in
+++ b/linux/snap/snapcraft.yaml.in
@@ -26,7 +26,7 @@ parts:
       OPAMROOT=$SNAPCRAFT_PART_INSTALL/coq-platform/ opam clean
       find $SNAPCRAFT_PART_INSTALL/coq-platform/@@PLATFORM_RELEASE@@/ \( -name '*.byte.exe' -o -name '*.byte' -o -name '*.cm[aioxt]' -o -name '*.cmxa' -o -name '*.[oa]' -o -name '*.cmti' -o -name '*.glob' \) -type f  -delete
       find $SNAPCRAFT_PART_INSTALL/coq-platform/@@PLATFORM_RELEASE@@/bin/ -maxdepth 1 -mindepth 1 \! \( -name 'coq*' -o -name 'clight*' -o -name 'gappa' \) -exec rm -f {} \;
-      find $SNAPCRAFT_PART_INSTALL/coq-platform/@@PLATFORM_RELEASE@@/lib/ -maxdepth 1 -mindepth 1 \! \( -name 'coq' -o -name 'stublibs' \) -exec rm -rf {} \;
+      find $SNAPCRAFT_PART_INSTALL/coq-platform/@@PLATFORM_RELEASE@@/lib/ -maxdepth 1 -mindepth 1 \! \( -name 'coq*' -o -name 'stublibs' \) -exec rm -rf {} \;
       rm -rf $SNAPCRAFT_PART_INSTALL/coq-platform/@@PLATFORM_RELEASE@@/share/ocaml-secondary-compiler
       rm -rf $SNAPCRAFT_PART_INSTALL/coq-platform/repo/
 


### PR DESCRIPTION
Coq 8.15 installs stuff in lib/coq and lib/coq-core (and maybe also lib/coq-stlib).