### PR TITLE
Update UniMath.

### DIFF
--- a/package_picks/package-pick-8.13~2022.01.sh
+++ b/package_picks/package-pick-8.13~2022.01.sh
@@ -102,7 +102,7 @@ then
 
   # Univalent Mathematics (UniMath)
   # Note: coq-unimath requires too much memory for 32 bit architectures
-  if [ "${BITSIZE}" == "64" ]; then PACKAGES="${PACKAGES} coq-unimath.20210807"; fi
+  if [ "${BITSIZE}" == "64" ]; then PACKAGES="${PACKAGES} coq-unimath.20220204"; fi
 
   # Code extraction
   PACKAGES="${PACKAGES} coq-simple-io.1.6.0"

--- a/package_picks/package-pick-8.14~2022.01.sh
+++ b/package_picks/package-pick-8.14~2022.01.sh
@@ -101,7 +101,7 @@ then
   # Note: coq-unimath requires too much memory for 32 bit architectures
   if [ "${BITSIZE}" == "64" ]
   then
-    PACKAGES="${PACKAGES} coq-unimath.20210807"       # pick confirmed https://github.com/UniMath/UniMath/issues/1398
+    PACKAGES="${PACKAGES} coq-unimath.20220204"       # pick confirmed https://github.com/UniMath/UniMath/issues/1442
   fi 
 
   # Code extraction

--- a/package_picks/package-pick-8.15~beta1.sh
+++ b/package_picks/package-pick-8.15~beta1.sh
@@ -102,7 +102,7 @@ then
   # Note: coq-unimath requires too much memory for 32 bit architectures
   if [ "${BITSIZE}" == "64" ]
   then
-    PACKAGES="${PACKAGES} coq-unimath.20210807"
+    PACKAGES="${PACKAGES} coq-unimath.20220204"
   fi 
 
   # Code extraction


### PR DESCRIPTION
We would like to update UniMath to the last version ([2022-02-04](https://github.com/coq/opam-coq-archive/pull/2094)) in the soon to be released version of Coq Platform (https://github.com/UniMath/UniMath/issues/1442).

This is my attempt at modifying the package pick files accordingly, but I'm unsure how is the intende usage and workflow, so please revise this PR and tell if it as expected.
