### PR TITLE
add smoke test files for ott and coq-ott

### DIFF
--- a/test_files/coq-ott/regexp.v
+++ b/test_files/coq-ott/regexp.v
@@ -1,0 +1,56 @@
+Require Import Arith.
+Require Import Bool.
+Require Import List.
+Require Import Ott.ott_list_core.
+
+
+Import ListNotations.
+Section RegExp.
+Variable char : Type.
+
+Definition c : Type := char. (*r character *)
+
+Inductive r : Type :=  (*r regexp *)
+ | r_zero : r
+ | r_unit : r
+ | r_char (c5:c)
+ | r_plus (r5:r) (r':r)
+ | r_times (r5:r) (r':r)
+ | r_star (r5:r).
+
+Definition s : Type := list char.
+(** definitions *)
+
+(* defns regexp_ins *)
+Inductive s_in_regexp_lang : s -> r -> Prop :=    (* defn s_in_regexp_lang *)
+ | s_in_regexp_lang_unit : 
+     s_in_regexp_lang  []  r_unit
+ | s_in_regexp_lang_char : forall (c5:c),
+     s_in_regexp_lang  ( c5  :: [])  (r_char c5)
+ | s_in_regexp_lang_plus_1 : forall (s5:s) (r1 r2:r),
+     s_in_regexp_lang s5 r1 ->
+     s_in_regexp_lang s5 (r_plus r1 r2)
+ | s_in_regexp_lang_plus_2 : forall (s5:s) (r1 r2:r),
+     s_in_regexp_lang s5 r2 ->
+     s_in_regexp_lang s5 (r_plus r1 r2)
+ | s_in_regexp_lang_times : forall (s5 s':s) (r1 r2:r),
+     s_in_regexp_lang s5 r1 ->
+     s_in_regexp_lang s' r2 ->
+     s_in_regexp_lang  ( s5  ++  s' )  (r_times r1 r2)
+ | s_in_regexp_lang_star_1 : forall (r5:r),
+     s_in_regexp_lang  []  (r_star r5)
+ | s_in_regexp_lang_star_2 : forall (s5 s':s) (r5:r),
+     s_in_regexp_lang s5 r5 ->
+     s_in_regexp_lang s' (r_star r5) ->
+     s_in_regexp_lang  ( s5  ++  s' )  (r_star r5).
+(** definitions *)
+
+(* defns regexp_ins_c *)
+Inductive s_in_regexp_c_lang : s -> r -> c -> Prop :=    (* defn s_in_regexp_c_lang *)
+ | s_in_regexp_c_lang_cs : forall (s5:s) (r5:r) (c5:c),
+     s_in_regexp_lang  (  ( c5  :: [])   ++  s5 )  r5 ->
+     s_in_regexp_c_lang s5 r5 c5.
+End RegExp.
+
+
+

--- a/test_files/ott/regexp.ott
+++ b/test_files/ott/regexp.ott
@@ -1,0 +1,96 @@
+embed
+{{ coq
+Import ListNotations.
+Section RegExp.
+Variable char : Type.
+}}
+metavar c ::=
+          {{ lex alphanum }}
+          {{ com character }}
+          {{ coq char }}
+          {{ hol char }}
+          {{ coq-universe Type }}
+grammar
+s :: s_ ::=
+  {{ com string }}
+  {{ coq list char }}
+  {{ hol char list }}
+  {{ coq-universe Type }}
+  | e :: M :: empty
+    {{ coq [] }}
+    {{ hol [] }}
+    {{ tex \epsilon }}
+  | c :: M :: char
+    {{ coq ([[c]] :: []) }}
+    {{ hol ([[c]] :: []) }}
+  | s s' :: M :: concat
+    {{ coq ([[s]] ++ [[s']]) }}
+    {{ hol ([[s]] ++ [[s']]) }}
+
+r :: r_ ::=
+  {{ com regexp }}
+  {{ coq-universe Type }}
+  | 0 :: :: zero
+  | 1 :: :: unit
+  | c :: :: char
+  | r + r' :: :: plus
+  | r r' :: :: times
+  | r * :: :: star
+    {{ tex [[r]]^* }}
+
+terminals :: terminals_ ::=
+	  | in :: :: in {{ tex \in }}
+	  | L :: :: L {{ tex \mathit{L} }}	
+
+formula :: formula_ ::=
+	| judgement :: :: judgement
+
+defns
+  regexp_ins :: '' ::=
+
+defn
+ s in L ( r ) :: :: s_in_regexp_lang :: s_in_regexp_lang_
+ {{ com string in regexp language }} by
+
+ --------- :: unit
+ e in L(1)
+
+ ---------- :: char
+ c in L(c)
+
+ s in L(r1)
+ ------------- :: plus_1
+ s in L(r1+r2)
+
+ s in L(r2)
+ ------------- :: plus_2
+ s in L(r1+r2)
+
+ s in L(r1)
+ s' in L(r2)
+ ---------------- :: times
+ s s' in L(r1 r2)
+
+ ---------- :: star_1
+ e in L(r*)
+
+ s in L(r)
+ s' in L(r*)
+ ------------- :: star_2
+ s s' in L(r*)
+
+defns
+  regexp_ins_c :: '' ::=
+
+defn
+ s in L ( r ; c ) :: :: s_in_regexp_c_lang :: s_in_regexp_c_lang_
+ {{ com string in regexp c language }} by 
+
+ c s in L(r)
+ ----------- :: cs
+ s in L(r;c)
+
+embed
+{{ coq
+End RegExp.
+}}


### PR DESCRIPTION
Here I contribute test files under license CC-0 for both the Ott tool (`ott` package) and for Ott's Coq library (`coq-ott` package); the Coq library is usable standalone.

Even though only `regexp.v` is currently used in the smoke test kit, I think it's a good idea to have a test for Ott itself in case we want to validate a patch for Windows.

`regexp.ott` should be tested as follows after installation of ~~both `coq` and~~ `ott`:
```shell
ott -o regexp.v regexp.ott
```
This should result in a file `regexp.v`. This file can be further tested as below.

`regexp.v` should be tested as follows after installation of both `coq` and `coq-ott`:
```shell
coqc regexp.v
```
Note that I removed the Ott version output from the included `regexp.v`; if you generate `regexp.v` there will be a Coq comment with the Ott version number.