### PR TITLE
Platform for 8.16: switch to OCaml 4.14.0

### DIFF
--- a/package_picks/package-pick-8.16~2022.09~beta1.sh
+++ b/package_picks/package-pick-8.16~2022.09~beta1.sh
@@ -32,7 +32,7 @@ COQ_PLATFORM_VERSION_DESCRIPTION='This version of Coq Platform 2022.04.1 include
 COQ_PLATFORM_VERSION_DESCRIPTION+='This is beta release with complete package pick and intended for package maintainers and early adopters. '
 
 # The OCaml version to use for this pick (just the version number - options are elaborated in a platform dependent way)
-COQ_PLATFORM_OCAML_VERSION='4.13.1'
+COQ_PLATFORM_OCAML_VERSION='4.14.0'
 
 ###################### PACKAGE SELECTION #####################
 

--- a/shell_scripts/install_opam.sh
+++ b/shell_scripts/install_opam.sh
@@ -181,6 +181,7 @@ then
       4.10.2) COQ_PLATFORM_OCAML_VARIANT="ocaml-base-compiler.${COQ_PLATFORM_OCAML_VERSION}";;
       4.12.1) COQ_PLATFORM_OCAML_VARIANT="ocaml-variants.${COQ_PLATFORM_OCAML_VERSION}+options,ocaml-option-flambda";;
       4.13.1) COQ_PLATFORM_OCAML_VARIANT="ocaml-variants.${COQ_PLATFORM_OCAML_VERSION}+options,ocaml-option-flambda";;
+      4.14.0) COQ_PLATFORM_OCAML_VARIANT="ocaml-variants.${COQ_PLATFORM_OCAML_VERSION}+options,ocaml-option-flambda";;
       *) echo "Unsupported OCaml version ${COQ_PLATFORM_OCAML_VERSION}"; return 1;;
     esac
   fi


### PR DESCRIPTION
OCaml 4.14 fixes some issues with debugging and seems to not have any known regression.

I understand if it's too late to change, and feel free to close if unhelpful. But I wanted to confirm this at least passes CI: it worked locally, while it didn't with the last Coq 8.15 platform (b/c of elpi and camlp5).