### PR TITLE
Opam: fix python-3.9 variant for gentoo linux

### DIFF
--- a/opam/opam-repository/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/opam/opam-repository/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -14,7 +14,7 @@ depexts: [
   ["python3"] {os-distribution = "ol"}
   ["python"] {os-distribution = "arch"}
   ["python3"] {os-family = "suse"}
-  ["dev-lang/python:3.6"] {os-distribution = "gentoo"}
+  ["dev-lang/python:3.9"] {os-distribution = "gentoo"}
   ["python3"] {os = "openbsd"}
   ["lang/python39"] {os = "netbsd"}
   ["lang/python39"] {os = "freebsd"}


### PR DESCRIPTION
Bump the python variant version for gentoo linux to 3.9 since 3.6 no longer exists in the repository.