### PR TITLE
Windows: use python3 as default python

### DIFF
--- a/shell_scripts/init_cygwin_fixes.sh
+++ b/shell_scripts/init_cygwin_fixes.sh
@@ -15,7 +15,7 @@
 
 if [[ "$OSTYPE" == cygwin ]]
 then
-  ln -s -f /usr/bin/python2 /usr/bin/python
+  ln -s -f /usr/bin/python3 /usr/bin/python
 fi
 
 ###################### Fix tar in 32 bit cygwin #####################


### PR DESCRIPTION
 (required since python2 was removed from cygwin)