### PR TITLE
[installer] [windows] Don't remove sexplib0 library.

### DIFF
--- a/shell_scripts/installer_create_tree.sh
+++ b/shell_scripts/installer_create_tree.sh
@@ -82,7 +82,7 @@ OPAM_FILE_EXCLUSION_LIST[coq-compcert-32]=OPAM_FILE_EXCLUSION_LIST[coq-compcert]
 # Since QuickChick requires OCamlc at run time, it is also excluded
 
 OPAM_PACKAGE_EXCLUSION_LIST="ocaml"$'\n'"ocaml-variants"$'\n'"ocaml-base-compiler"$'\n'"ocaml-compiler-libs"$'\n'"ocaml-config"$'\n'"ocaml-secondary-compiler"$'\n'"ocamlfind-secondary"$'\n'"coq-quickchick"
-OPAM_PACKAGE_EXCLUSION_LIST="${OPAM_PACKAGE_EXCLUSION_LIST}"$'\n'"sexplib0"$'\n'"csexp"$'\n'"ocamlbuild"$'\n'"cppo"
+OPAM_PACKAGE_EXCLUSION_LIST="${OPAM_PACKAGE_EXCLUSION_LIST}"$'\n'"csexp"$'\n'"ocamlbuild"$'\n'"cppo"
 
 # Regexp for packages to ignore
 


### PR DESCRIPTION
This is needed by SerAPI, coq-lsp, and likely others.

Looking at git history, it seems this package was added to this list by mistake. Confirmed to fix problems of `coq-lsp` / `SerAPI` in Windows.