### PR TITLE
Opam: coq-metacoq-template: add back the 'rm _PluginProject' fix

### DIFF
--- a/opam/opam-coq-archive/released/packages/coq-metacoq-template/coq-metacoq-template.1.2+8.16/opam
+++ b/opam/opam-coq-archive/released/packages/coq-metacoq-template/coq-metacoq-template.1.2+8.16/opam
@@ -22,6 +22,7 @@ license: "MIT"
 patches: [ "Fix make issues Coq Platform CI.patch" ]
 build: [
   ["bash" "./configure.sh"]
+  ["rm" "-f" "template-coq/_PluginProject" "template-coq/_TemplateCoqProject"]
   [make "-j" "%{jobs}%" "template-coq"]
 ]
 install: [

--- a/opam/opam-coq-archive/released/packages/coq-metacoq-template/coq-metacoq-template.1.2+8.17/opam
+++ b/opam/opam-coq-archive/released/packages/coq-metacoq-template/coq-metacoq-template.1.2+8.17/opam
@@ -22,6 +22,7 @@ license: "MIT"
 patches: [ "Fix make issues Coq Platform CI.patch" ]
 build: [
   ["bash" "./configure.sh"]
+  ["rm" "-f" "template-coq/_PluginProject" "template-coq/_TemplateCoqProject"]
   [make "-j" "%{jobs}%" "template-coq"]
 ]
 install: [

--- a/opam/opam-coq-archive/released/packages/coq-metacoq-template/coq-metacoq-template.1.2.1+8.18/opam
+++ b/opam/opam-coq-archive/released/packages/coq-metacoq-template/coq-metacoq-template.1.2.1+8.18/opam
@@ -22,6 +22,7 @@ license: "MIT"
 patches: [ "Fix make issues Coq Platform CI.patch" ]
 build: [
   ["bash" "./configure.sh"]
+  ["rm" "-f" "template-coq/_PluginProject" "template-coq/_TemplateCoqProject"]
   [make "-j" "%{jobs}%" "-C" "template-coq"]
 ]
 install: [

--- a/opam/opam-coq-archive/released/packages/coq-metacoq-template/coq-metacoq-template.1.3.1+8.19/opam
+++ b/opam/opam-coq-archive/released/packages/coq-metacoq-template/coq-metacoq-template.1.3.1+8.19/opam
@@ -22,6 +22,7 @@ license: "MIT"
 patches: [ "Fix make issues Coq Platform CI.patch" ]
 build: [
   ["bash" "./configure.sh"]
+  ["rm" "-f" "template-coq/_PluginProject" "template-coq/_TemplateCoqProject"]
   [make "-j" "%{jobs}%" "-C" "template-coq"]
 ]
 install: [


### PR DESCRIPTION
As discussed in [Zulip](https://coq.zulipchat.com/#narrow/stream/237658-MetaCoq/topic/coq-metacoq-template.201.2E2.2E1.2B8.2E18.20suddenly.20failing.20in.20CI/near/453432560) both the patch and the rm are needed for stable builds.