### PR TITLE
Windows: enable long path support in cygwin MinGW toolchain and Windows registry

### DIFF
--- a/package_picks/package-pick-8.19~2024.01+beta1.sh
+++ b/package_picks/package-pick-8.19~2024.01+beta1.sh
@@ -66,6 +66,11 @@ fi
 
 if  [[ "${COQ_PLATFORM_EXTENT}"  =~ ^[fFxX] ]]
 then
+  # Some dependencies which need to be installed upfront to avoid recompilation
+  # sexplib depends on sexplib0 which has a version 0.17.0 compatible with OCaml 4.X, but sexplib 0.17.0 requires OCaml 5.X
+  # so if sexplib0 is installed first, we get 0.17.0 but later need to revert to 0.16.0 when sexpliv ist installed (required by coq-serapi)  
+  PACKAGES="${PACKAGES} sexplib"  
+  
   # Standard library extensions
   PACKAGES="${PACKAGES} coq-bignums.9.0.0+coq8.19"
   PACKAGES="${PACKAGES} coq-ext-lib.0.12.1"
@@ -200,12 +205,7 @@ then
   PACKAGES="${PACKAGES} coq-record-update.0.3.4"
 
   # Communication with coqtop
-  if [[ "$OSTYPE" != cygwin ]]
-  then
-    # Windows: path length issues
-    PACKAGES="${PACKAGES} coq-serapi.8.19.0+0.19.2"
-
-  fi
+  PACKAGES="${PACKAGES} coq-serapi.8.19.0+0.19.2"
 
   # fiat crypto, bedrock2, rupicola and dependencies
   if [ "${BITSIZE}" == "64" ]

--- a/shell_scripts/ask_long_path.sh
+++ b/shell_scripts/ask_long_path.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+###################### COPYRIGHT/COPYLEFT ######################
+
+# (C) 2024 Michael Soegtrop
+
+# Released to the public under the
+# Creative Commons CC0 1.0 Universal License
+# See https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt
+
+###################### USER CHOICES #####################
+
+# Enable long paths in Windows
+
+if [[ "${COQREGTESTING:-n}" == y ]]
+then
+  ANSWER=y
+else
+cat <<EOH
+========================= WINDOWS LONG PATH SUPPORT =========================
+By default on Windows the length of file paths is restricted to 259 character.
+This is not sufficient for building Coq Platform, so long filename support
+must be enabled.
+
+This enablement is done in two steps:
+- enable it in each executable built by Coq Platform
+- enable it in the Windows registry
+
+Both criteria must be fullfilled for an executable in order to enable long
+path support. For this reason it is not dangerous to enable it in the
+registry - applictions which do not support it do not enable it in their
+manifests.
+
+The setup has detected that long paths in not enabled in the registry.
+If you want to enable it automatically now, select Y - otherwise C.
+========================= WINDOWS LONG PATH SUPPORT =========================
+EOH
+ask_user_opt1_cancel "Enable long path support in registry (y)" yY "enable long paths in registry"
+fi

--- a/windows/default-manifest.rc
+++ b/windows/default-manifest.rc
@@ -1,0 +1,35 @@
+LANGUAGE 0, 0
+
+/* CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST MOVEABLE PURE DISCARDABLE */
+1 24 MOVEABLE PURE DISCARDABLE
+BEGIN
+  "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>\n"
+  "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1"" manifestVersion=""1.0"" xmlns:asmv3=""urn:schemas-microsoft-com:asm.v3"">\n"
+  "  <trustInfo xmlns=""urn:schemas-microsoft-com:asm.v3"">\n"
+  "    <security>\n"
+  "      <requestedPrivileges>\n"
+  "        <requestedExecutionLevel level=""asInvoker""/>\n"
+  "      </requestedPrivileges>\n"
+  "    </security>\n"
+  "  </trustInfo>\n"
+  "  <compatibility xmlns=""urn:schemas-microsoft-com:compatibility.v1"">\n"
+  "    <application>\n"
+  "      <!--The ID below indicates application support for Windows Vista -->\n"
+  "      <supportedOS Id=""{e2011457-1546-43c5-a5fe-008deee3d3f0}""/>\n"
+  "      <!--The ID below indicates application support for Windows 7 -->\n"
+  "      <supportedOS Id=""{35138b9a-5d96-4fbd-8e2d-a2440225f93a}""/>\n"
+  "      <!--The ID below indicates application support for Windows 8 -->\n"
+  "      <supportedOS Id=""{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}""/>\n"
+  "      <!--The ID below indicates application support for Windows 8.1 -->\n"
+  "      <supportedOS Id=""{1f676c76-80e1-4239-95bb-83d0f6d0da78}""/> \n"
+  "      <!--The ID below indicates application support for Windows 10 -->\n"
+  "      <supportedOS Id=""{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}""/> \n"
+  "    </application>\n"
+  "  </compatibility>\n"
+  "  <asmv3:application>\n"
+  "    <asmv3:windowsSettings xmlns=""http://schemas.microsoft.com/SMI/2016/WindowsSettings"">\n"
+  "      <longPathAware>true</longPathAware>\n"
+  "    </asmv3:windowsSettings>\n"
+  "  </asmv3:application>\n"
+  "</assembly>\n"
+END

--- a/windows/long-paths.md
+++ b/windows/long-paths.md
@@ -1,0 +1,108 @@
+# Background
+
+In order to allow long paths in Windows, two conditions must be met
+
+- this must be enabled in the registry
+- the manifest of the executables must state that they do support this
+
+See
+
+https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later
+
+# Default Manifest
+
+This default manifest enables long paths on Windows for everything compiled / linked after it has been installed (assuming the registry seeting is set, see eblow)
+
+The manifest is inspired by
+
+https://discuss.ocaml.org/t/ocaml-on-windows-the-long-paths-issue/13283
+and
+https://github.com/ManasJayanth/windows-default-manifest/
+
+This file is not taken from there, though, it is a merge of the (FSFAP license) file in
+
+https://cygwin.com/packages/summary/windows-default-manifest-src.html
+
+```
+LANGUAGE 0, 0
+
+/* CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST MOVEABLE PURE DISCARDABLE */
+1 24 MOVEABLE PURE DISCARDABLE
+BEGIN
+  "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>\n"
+  "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1"" manifestVersion=""1.0"">\n"
+  "  <trustInfo xmlns=""urn:schemas-microsoft-com:asm.v3"">\n"
+  "    <security>\n"
+  "      <requestedPrivileges>\n"
+  "        <requestedExecutionLevel level=""asInvoker""/>\n"
+  "      </requestedPrivileges>\n"
+  "    </security>\n"
+  "  </trustInfo>\n"
+  "  <compatibility xmlns=""urn:schemas-microsoft-com:compatibility.v1"">\n"
+  "    <application>\n"
+  "      <!--The ID below indicates application support for Windows Vista -->\n"
+  "      <supportedOS Id=""{e2011457-1546-43c5-a5fe-008deee3d3f0}""/>\n"
+  "      <!--The ID below indicates application support for Windows 7 -->\n"
+  "      <supportedOS Id=""{35138b9a-5d96-4fbd-8e2d-a2440225f93a}""/>\n"
+  "      <!--The ID below indicates application support for Windows 8 -->\n"
+  "      <supportedOS Id=""{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}""/>\n"
+  "      <!--The ID below indicates application support for Windows 8.1 -->\n"
+  "      <supportedOS Id=""{1f676c76-80e1-4239-95bb-83d0f6d0da78}""/> \n"
+  "      <!--The ID below indicates application support for Windows 10 -->\n"
+  "      <supportedOS Id=""{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}""/> \n"
+  "    </application>\n"
+  "  </compatibility>\n"
+  "</assembly>\n"
+END
+```
+
+and the example here:
+
+https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests#longpathaware
+
+## Build default manifest
+```
+x86_64-w64-mingw32-windres -F pe-x86-64 windows/default-manifest.rc -o windows/default-manifest.o
+cp windows/default-manifest.o /usr/x86_64-w64-mingw32/sys-root/mingw/lib/default-manifest.o
+```
+
+# Regsity setting
+
+See https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later
+
+```
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem]
+"LongPathsEnabled"=dword:00000001
+```
+
+To install this file run on the cygwin prompt:
+
+```
+cygstart --action=runas REG IMPORT long-path.reg
+```
+**THIS DOES NOT WORK!**
+
+or alternatively
+
+```
+cygstart --action=runas REG ADD 'HKLM\SYSTEM\CurrentControlSet\Control\FileSystem' /v LongPathsEnabled /t REG_DWORD /d 1 /f
+```
+
+Löschen des Schlüssels
+
+```
+cygstart --action=runas REG DELETE 'HKLM\SYSTEM\CurrentControlSet\Control\FileSystem' /v LongPathsEnabled
+```
+
+To query on the cygwin prompt run:
+
+```
+REG QUERY 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem' /v LongPathsEnabled
+
+FEHLER: Der angegebene Registrierungsschlüssel bzw. Wert wurde nicht gefunden.
+
+HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem
+    LongPathsEnabled    REG_DWORD    0x1
+```


### PR DESCRIPTION
should permanently fix coq-serapi issues