### PR TITLE
chore(ci): fix issue space disk

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -80,7 +80,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install bubblewrap build-essential
-          sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
           echo "=== Disk after apt install ==="
           df -h
         
@@ -97,6 +96,7 @@ jobs:
           echo
           echo "=== Top 15 biggest directories in ~ ==="
           du -xhd1 ~ 2>/dev/null | sort -hr | head -n 15 || true
+          
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:


### PR DESCRIPTION
Fix the issue on Ubuntu regarding the error for coq-fiat-crypto.0.1.3 Error: System error: "No space left on device" on Ubuntu 8.20 and 8.19